### PR TITLE
Update project URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     description='A pure python3 version of ICMP ping implementation using raw socket.',
     long_description=long_desc,
     long_description_content_type='text/markdown',
-    url='https://github.com/M-o-a-T/asyncping3',
+    url='https://github.com/M-o-a-T/ping3',
     author='Matthias Urlichs',
     author_email='matthias@urlichs.de',
     license='MIT',


### PR DESCRIPTION
The URL seems to have been accidentally incorrectly changed in the past using a mass search and replace so the package now points to a project homepage that doesn't exist on PyPI.